### PR TITLE
Segwit leftovers require removal #2

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -154,13 +154,6 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
                        ? nMedianTimePast
                        : pblock->GetBlockTime();
 
-    // Decide whether to include witness transactions
-    // This is only needed in case the witness softfork activation is reverted
-    // (which would require a very deep reorganization) or when
-    // -promiscuousmempoolflags is used.
-    // TODO: replace this with a call to main to assess validity of a mempool
-    // transaction (which in most cases can be a no-op).
-
 
     addPriorityTxs();
     int nPackagesSelected = 0;

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -594,11 +594,8 @@ UniValue getblocktemplate(const JSONRPCRequest& request)
         int index_in_template = i - 1;
         entry.push_back(Pair("fee", pblocktemplate->vTxFees[index_in_template]));
         int64_t nTxSigOps = pblocktemplate->vTxSigOpsCost[index_in_template];
-        if (fPreSegWit) {
-            assert(nTxSigOps % WITNESS_SCALE_FACTOR == 0);
-            nTxSigOps /= WITNESS_SCALE_FACTOR;
-        }
         entry.push_back(Pair("sigops", nTxSigOps));
+        entry.push_back(Pair("size", GetTransactionWeight(tx)));
 
         transactions.push_back(entry);
     }
@@ -691,9 +688,6 @@ UniValue getblocktemplate(const JSONRPCRequest& request)
     result.push_back(Pair("bits", strprintf("%08x", pblock->nBits)));
     result.push_back(Pair("height", (int64_t)(pindexPrev->nHeight+1)));
 
-    //if (!pblocktemplate->vchCoinbaseCommitment.empty() && fSupportsSegwit) {
-    //    result.push_back(Pair("default_witness_commitment", HexStr(pblocktemplate->vchCoinbaseCommitment.begin(), pblocktemplate->vchCoinbaseCommitment.end())));
-    //}
 
     return result;
 }
@@ -759,14 +753,6 @@ UniValue submitblock(const JSONRPCRequest& request)
                 return "duplicate-invalid";
             // Otherwise, we might only have the header - process the block before returning
             fBlockPresent = true;
-        }
-    }
-
-    {
-        LOCK(cs_main);
-        BlockMap::iterator mi = mapBlockIndex.find(block.hashPrevBlock);
-        if (mi != mapBlockIndex.end()) {
-            //UpdateUncommittedBlockStructures(block, mi->second, Params().GetConsensus());
         }
     }
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -91,7 +91,7 @@ static void CheckBlockIndex(const Consensus::Params& consensusParams);
 /** Constant stuff for coinbase transactions we create: */
 CScript COINBASE_FLAGS;
 
-const std::string strMessageMagic = "Goldcoin Signed Message:\n";
+const std::string strMessageMagic = "GoldCoin (GLD) Signed Message:\n";
 
 // Internal stuff
 namespace {
@@ -480,11 +480,6 @@ int64_t GetTransactionSigOpCost(const CTransaction& tx, const CCoinsViewCache& i
         nSigOps += GetP2SHSigOpCount(tx, inputs) * WITNESS_SCALE_FACTOR;
     }
 
-    for (unsigned int i = 0; i < tx.vin.size(); i++)
-    {
-        const CTxOut &prevout = inputs.GetOutputFor(tx.vin[i]);
-        nSigOps += 0;//CountWitnessSigOps(tx.vin[i].scriptSig, prevout.scriptPubKey, &tx.vin[i].scriptWitness, flags);
-    }
     return nSigOps;
 }
 
@@ -2670,7 +2665,6 @@ bool ReceivedBlockTransactions(const CBlock &block, CValidationState& state, CBl
     pindexNew->nDataPos = pos.nPos;
     pindexNew->nUndoPos = 0;
     pindexNew->nStatus |= BLOCK_HAVE_DATA;
-
     pindexNew->RaiseValidity(BLOCK_VALID_TRANSACTIONS);
     setDirtyBlockIndex.insert(pindexNew);
 
@@ -2836,7 +2830,7 @@ bool CheckBlock(const CBlock& block, CValidationState& state, const Consensus::P
     // because we receive the wrong transactions for it.
 
     // Size limits
-    if (block.vtx.empty() || block.vtx.size() > MAX_BLOCK_BASE_SIZE || ::GetSerializeSize(block, SER_NETWORK, PROTOCOL_VERSION | SERIALIZE_TRANSACTION_NO_WITNESS) > MAX_BLOCK_BASE_SIZE)
+    if (block.vtx.empty() || block.vtx.size() > MAX_BLOCK_BASE_SIZE || ::GetSerializeSize(block, SER_NETWORK, PROTOCOL_VERSION) > MAX_BLOCK_BASE_SIZE)
         return state.DoS(100, false, REJECT_INVALID, "bad-blk-length", false, "size limits failed");
 
     // First transaction must be coinbase, the rest must not be
@@ -3566,12 +3560,6 @@ bool RewindBlockIndex(const CChainParams& params)
     LOCK(cs_main);
 
     int nHeight = 1;
-    //while (nHeight <= chainActive.Height()) {
-    //    if (IsWitnessEnabled(chainActive[nHeight - 1], params.GetConsensus()) && !(chainActive[nHeight]->nStatus & BLOCK_OPT_WITNESS)) {
-    //        break;
-    //    }
-    //    nHeight++;
-    //}
 
     // nHeight is now the height of the first insufficiently-validated block, or tipheight + 1
     CValidationState state;


### PR DESCRIPTION
Issue #2 

First part of SegWit removal from mining and validation.

There are some leftover parts of SegWit, though values have been changed to default (pre-segwit values).
```
static const int SERIALIZE_TRANSACTION_NO_WITNESS = 0x40000000;

static const int WITNESS_SCALE_FACTOR = 1;
```

These constants could be removed from all code.  GetTransactionWeight is the current method to get Transaction Size.  Need to check that some calls to GetTransactionWeight were not deleted by  mistake.

