### PR TITLE
Repair Reg Test

### DIFF
--- a/qa/rpc-tests/listsinceblock.py
+++ b/qa/rpc-tests/listsinceblock.py
@@ -48,7 +48,7 @@ class ListSinceBlockTest (BitcoinTestFramework):
 
         assert_equal(self.nodes[0].getbalance(), 0)
         assert_equal(self.nodes[1].getbalance(), 0)
-        assert_equal(self.nodes[2].getbalance(), 50)
+        assert_equal(self.nodes[2].getbalance(), 10000)
         assert_equal(self.nodes[3].getbalance(), 0)
 
         # Split network into two

--- a/qa/rpc-tests/rawtransactions.py
+++ b/qa/rpc-tests/rawtransactions.py
@@ -140,7 +140,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         self.sync_all()
         self.nodes[0].generate(1)
         self.sync_all()
-        assert_equal(self.nodes[0].getbalance(), bal+Decimal('50.00000000')+Decimal('2.19000000')) #block reward + tx
+        assert_equal(self.nodes[0].getbalance(), bal+Decimal('10000.00000000')+Decimal('2.19000000')) #block reward + tx
 
         # getrawtransaction tests
         # 1. valid parameters - only supply txid

--- a/qa/rpc-tests/test_framework/mininode.py
+++ b/qa/rpc-tests/test_framework/mininode.py
@@ -1616,9 +1616,9 @@ class NodeConn(asyncore.dispatcher):
         b"blocktxn": msg_blocktxn
     }
     MAGIC_BYTES = {
-        "mainnet": b"\xfb\xc0\xb6\xdb",   # mainnet
-        "testnet3": b"\xfc\xc1\xb7\xdc",  # testnet3
-        "regtest": b"\xfa\xbf\xb5\xda",   # regtest
+        "mainnet": b"\xfd\xc2\xb4\xdd",   # mainnet
+        "testnet3": b"\xfd\xc2\xb4\xdd",  # testnet3
+        "regtest": b"\xfe\xc3\xb5\xde",   # regtest
     }
 
     def __init__(self, dstaddr, dstport, rpc, callback, net="regtest", services=NODE_NETWORK, send_version=True):

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -290,18 +290,20 @@ public:
     CRegTestParams() {
         strNetworkID = "regtest";
 
-        consensus.julyFork = 10;
-        consensus.octoberFork = 25;
-        consensus.novemberFork = 30;
-        consensus.novemberFork2 = 35;
-        consensus.mayFork = 160;
-        consensus.julyFork2 = 200;
-        consensus.febFork = 205;
+        //GoldCoin forks are not activated on RegTest
+        consensus.julyFork = 100000000;
+        consensus.octoberFork = 100000000;
+        consensus.novemberFork = 100000000;
+        consensus.novemberFork2 = 100000000;
+        consensus.mayFork = 100000000;
+        consensus.julyFork2 = 100000000;
+        consensus.febFork = 100000001;
 
-        consensus.BIP34Height = 210;
-        consensus.BIP65Height = 220;
-        consensus.BIP66Height = 230;
-        consensus.powLimit = uint256S("00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+        consensus.BIP34Height = 100000000; // BIP34 has not activated on regtest (far in the future so block v1 are not rejected in tests)
+        consensus.BIP34Hash = uint256();
+        consensus.BIP65Height = 1351; // BIP65 activated on regtest (Used in rpc activation tests)
+        consensus.BIP66Height = 1251; // BIP66 activated on regtest (Used in rpc activation tests)
+        consensus.powLimit = uint256S("7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
         consensus.nPowTargetTimespan = 2.0 * 60 * 60; // Difficulty changes every 60 blocks
         consensus.nPowTargetSpacing = 2.0 * 60;
         consensus.fPowAllowMinDifficultyBlocks = true;
@@ -323,17 +325,17 @@ public:
          * The characters are rarely used upper ASCII, not valid as UTF-8, and produce
          * a large 32-bit integer with any alignment.
          */
-        pchMessageStart[0] = 0xfd;
-        pchMessageStart[1] = 0xc2;
-        pchMessageStart[2] = 0xb4;
-        pchMessageStart[3] = 0xdd;
+        pchMessageStart[0] = 0xfe;
+        pchMessageStart[1] = 0xc3;
+        pchMessageStart[2] = 0xb5;
+        pchMessageStart[3] = 0xde;
         nDefaultPort = 18130;
         nPruneAfterHeight = 1000;
 
-        genesis = CreateGenesisBlock(1296688602, 0, 0x207fffff, 1, 50 * COIN);
+        genesis = CreateGenesisBlock(1296688602, 4, 0x207fffff, 1, 50 * COIN);
         consensus.hashGenesisBlock = genesis.GetHash();
-        //assert(consensus.hashGenesisBlock == uint256S("0x530827f38f93b43ed12af0b3ad25a288dc02ed74d6d7857862df51fc56c416f9"));
-        //assert(genesis.hashMerkleRoot == uint256S("0x97ddfbbae6be97fd6cdf3e7ca13232a3afff2353e29badfab7f73011edd4ced9"));
+        assert(consensus.hashGenesisBlock == uint256S("0x46ca35deafc8f494066bc82f05d7f850479f228ab9196cd659da5fad831122eb"));
+        assert(genesis.hashMerkleRoot == uint256S("0xa215e67ba165202f75b6458d22fedd1a3ec4f03449a4c6b2a4b8130bfebd3b15"));
 
         vFixedSeeds.clear(); //!< Regtest mode doesn't have any fixed seeds.
         vSeeds.clear();      //!< Regtest mode doesn't have any DNS seeds.
@@ -345,7 +347,7 @@ public:
 
         checkpointData = (CCheckpointData){
             boost::assign::map_list_of
-            ( 0, uint256S("0x530827f38f93b43ed12af0b3ad25a288dc02ed74d6d7857862df51fc56c416f9"))
+            ( 0, uint256S("0x46ca35deafc8f494066bc82f05d7f850479f228ab9196cd659da5fad831122eb"))
         };
 
 

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -64,7 +64,10 @@ public:
 int64_t UpdateTime(CBlockHeader* pblock, const Consensus::Params& consensusParams, const CBlockIndex* pindexPrev)
 {
     int64_t nOldTime = pblock->nTime;
-    int64_t nNewTime = std::max(pindexPrev->GetMinTimeNext(), GetAdjustedTime());
+    int64_t nNewTime = pindexPrev->nHeight+1 > consensusParams.octoberFork ?
+                std::max(pindexPrev->GetMinTimeNext(), GetAdjustedTime()) :
+                std::max(pindexPrev->GetMedianTimePast()+1, GetAdjustedTime());
+
 
     if (nOldTime < nNewTime)
         pblock->nTime = nNewTime;


### PR DESCRIPTION
Create working RegTest that can mine blocks with generate().

This allows the qa/pull-tester/rpc-tests.py to run.  Some tests pass, some still fail.