### PR TITLE
Tests2

### DIFF
--- a/src/validation.h
+++ b/src/validation.h
@@ -58,11 +58,11 @@ static const bool DEFAULT_WHITELISTRELAY = true;
 /** Default for DEFAULT_WHITELISTFORCERELAY. */
 static const bool DEFAULT_WHITELISTFORCERELAY = true;
 /** Default for -minrelaytxfee, minimum relay fee for transactions */
-static const unsigned int DEFAULT_MIN_RELAY_TX_FEE = 100000;
+static const unsigned int DEFAULT_MIN_RELAY_TX_FEE = 1000000;
 //! -maxtxfee default
 static const CAmount DEFAULT_TRANSACTION_MAXFEE = 0.1 * COIN;
 //! Discourage users to set fees higher than this amount (in satoshis) per kB
-static const CAmount HIGH_TX_FEE_PER_KB = 0.01 * COIN;
+static const CAmount HIGH_TX_FEE_PER_KB = 1.0 * COIN;
 //! -maxtxfee will warn if called with a higher fee than this amount (in satoshis)
 static const CAmount HIGH_MAX_TX_FEE = 100 * HIGH_TX_FEE_PER_KB;
 /** Default for -limitancestorcount, max number of in-mempool ancestors */


### PR DESCRIPTION
#12 - Fix transaction tests by adding code that was removed when removing segwit code.  The tx_invalid test was failing because invalid transactions were testing as valid because half of the validation checks (for signatures) was removed.

Set  DEFAULT_MIN_RELAY_TX_FEE =  DEFAULT_BLOCK_MIN_TX_FEE (0.01 GLD).

Increased HIGH_TX_FEE_PER_KB to 1.0 GLD from 0.01 GLD, since 0.01 GLD is the default fee.

The Fee's were preventing some of the qa/pull-tester/rpc-tests.py from passing (#3).