### PR TITLE
Txn_Clone.py fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,16 @@
 *.tar.gz
 
+# Mav remove this before pushing
+src/bench/bench_litecoin
+src/litecoin-cli
+src/litecoin-tx
+src/litecoind
+src/qt/litecoin-qt
+src/qt/test/test_litecoin-qt
+src/test/test_litecoin
+src/test/test_litecoin_fuzzy
+test/
+
 *.exe
 src/goldcoin
 src/goldcoind

--- a/.gitignore
+++ b/.gitignore
@@ -1,14 +1,6 @@
 *.tar.gz
 
 # Mav remove this before pushing
-src/bench/bench_litecoin
-src/litecoin-cli
-src/litecoin-tx
-src/litecoind
-src/qt/litecoin-qt
-src/qt/test/test_litecoin-qt
-src/test/test_litecoin
-src/test/test_litecoin_fuzzy
 test/
 
 *.exe

--- a/qa/rpc-tests/txn_clone.py
+++ b/qa/rpc-tests/txn_clone.py
@@ -26,8 +26,8 @@ class TxnMallTest(BitcoinTestFramework):
         return super(TxnMallTest, self).setup_network(True)
 
     def run_test(self):
-        # All nodes should start with 1,250 BTC:
-        starting_balance = 1250
+        # All nodes should start with 250000 GLD:
+        starting_balance = 250000
         for i in range(4):
             assert_equal(self.nodes[i].getbalance(), starting_balance)
             self.nodes[i].getnewaddress("")  # bug workaround, coins generated assigned to first getnewaddress!
@@ -89,7 +89,7 @@ class TxnMallTest(BitcoinTestFramework):
         # Node0's balance should be starting balance, plus 50BTC for another
         # matured block, minus tx1 and tx2 amounts, and minus transaction fees:
         expected = starting_balance + fund_foo_tx["fee"] + fund_bar_tx["fee"]
-        if self.options.mine_block: expected += 50
+        if self.options.mine_block: expected += 10000
         expected += tx1["amount"] + tx1["fee"]
         expected += tx2["amount"] + tx2["fee"]
         assert_equal(self.nodes[0].getbalance(), expected)
@@ -132,9 +132,9 @@ class TxnMallTest(BitcoinTestFramework):
 
         # Check node0's total balance; should be same as before the clone, + 100 BTC for 2 matured,
         # less possible orphaned matured subsidy
-        expected += 100
+        expected += 10000*2
         if (self.options.mine_block): 
-            expected -= 50
+            expected -= 10000
         assert_equal(self.nodes[0].getbalance(), expected)
         assert_equal(self.nodes[0].getbalance("*", 0), expected)
 
@@ -149,7 +149,7 @@ class TxnMallTest(BitcoinTestFramework):
                                                                 + fund_foo_tx["fee"]
                                                                 -   29
                                                                 + fund_bar_tx["fee"]
-                                                                +  100)
+                                                                +  2*10000)
 
         # Node1's "from0" account balance
         assert_equal(self.nodes[1].getbalance("from0", 0), -(tx1["amount"] + tx2["amount"]))

--- a/src/wallet.backup
+++ b/src/wallet.backup
@@ -1,0 +1,8 @@
+# Wallet dump created by Goldcoin v0.14.2.0-3b01ba0-dirty
+# * Created on 2017-12-06T01:31:49Z
+# * Best block at time of backup was 103 (3e3bad234217faaeaa1b0aaef6d4fe043ba84c389f93e395b2bce10f4e961e5f),
+#   mined on 2017-12-06T01:31:49Z
+
+cVCdb2qv2sZzURKmdkHe8qp2sVuNWmWngn3LTzdh64VJgVjnmZ7W 2017-12-06T01:31:49Z change=1 # addr=moXVUXheEyezVN3uFGawg6DrNnxXN1Xtav
+
+# End of dump


### PR DESCRIPTION
Subsidy values were not accounted for in this test script. Assert values were then corrected to follow those reflected subsidy values. The script passes. 