### PR TITLE
Fix build on Boost 1.74 by including <boost/bind.hpp>

### DIFF
--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -16,6 +16,8 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include <deque>
+
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <signal.h>

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -74,6 +74,8 @@ const std::string BitcoinGUI::DEFAULT_UIPLATFORM =
 #endif
         ;
 
+#include <boost/bind.hpp>
+
 /** Display name for default wallet name. Uses tilde to avoid name
  * collisions in the future with additional wallets */
 const QString BitcoinGUI::DEFAULT_WALLET = "~Default";

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -23,6 +23,8 @@
 #include <QDebug>
 #include <QTimer>
 
+#include <boost/bind.hpp>
+
 class CBlockIndex;
 
 static const int64_t nClientStartupTime = GetTime();

--- a/src/qt/splashscreen.cpp
+++ b/src/qt/splashscreen.cpp
@@ -26,6 +26,8 @@
 #include <QPainter>
 #include <QRadialGradient>
 
+#include <boost/bind.hpp>
+
 SplashScreen::SplashScreen(Qt::WindowFlags f, const NetworkStyle *networkStyle) :
     QWidget(0, f), curAlignment(0)
 {

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -27,6 +27,7 @@
 #include <QList>
 
 #include <boost/foreach.hpp>
+#include <boost/bind.hpp>
 
 // Amount column is right-aligned it contains numbers
 static int column_alignments[] = {

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -29,6 +29,7 @@
 #include <QTimer>
 
 #include <boost/foreach.hpp>
+#include <boost/bind.hpp>
 
 WalletModel::WalletModel(const PlatformStyle *platformStyle, CWallet *_wallet, OptionsModel *_optionsModel, QObject *parent) :
     QObject(parent), wallet(_wallet), optionsModel(_optionsModel), addressTableModel(0),

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -53,6 +53,7 @@
 #include <boost/thread.hpp>
 #include <boost/asio.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
+#include <boost/bind.hpp>
 
 #if defined(NDEBUG)
 # error "Goldcoin cannot be compiled without assertions."

--- a/src/validationinterface.cpp
+++ b/src/validationinterface.cpp
@@ -7,6 +7,7 @@
 
 
 #include "validationinterface.h"
+#include <boost/bind.hpp>
 
 static CMainSignals g_signals;
 


### PR DESCRIPTION
This fixes compile errors on Boost 1.74 by adding these includes <boost/bind.hpp> to several files.

In addition, commit [7949](https://github.com/goldcoin/goldcoin/pull/72/commits/7949da1c0014ccf167d588551406617413526370) solves a compile error on Ubuntu 22.04 when looking for missing include:  `<deque>`