### PR TITLE
Revert: Remove redundant explicitly defined copy constructors

### DIFF
--- a/src/amount.h
+++ b/src/amount.h
@@ -47,6 +47,7 @@ public:
     explicit CFeeRate(const CAmount& _nSatoshisPerK): nSatoshisPerK(_nSatoshisPerK) { }
     /** Constructor for a fee rate in satoshis per kB. The size in bytes must not exceed (2^63 - 1)*/
     CFeeRate(const CAmount& nFeePaid, size_t nBytes);
+    CFeeRate(const CFeeRate& other) { nSatoshisPerK = other.nSatoshisPerK; }
     /**
      * Return the fee in satoshis for the given size in bytes.
      */

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -47,6 +47,11 @@ CTxMemPoolEntry::CTxMemPoolEntry(const CTransactionRef& _tx, const CAmount& _nFe
     nSigOpCostWithAncestors = sigOpCost;
 }
 
+CTxMemPoolEntry::CTxMemPoolEntry(const CTxMemPoolEntry& other)
+{
+    *this = other;
+}
+
 double
 CTxMemPoolEntry::GetPriority(unsigned int currentHeight) const
 {

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -119,6 +119,8 @@ public:
                     int64_t _nTime, double _entryPriority, unsigned int _entryHeight,
                     CAmount _inChainInputValue, bool spendsCoinbase,
                     int64_t nSigOpsCost, LockPoints lp);
+    
+    CTxMemPoolEntry(const CTxMemPoolEntry& other);
 
     const CTransaction& GetTx() const { return *this->tx; }
     CTransactionRef GetSharedTx() const { return this->tx; }


### PR DESCRIPTION
I'm reverting the previous pull request #74 because these two issue should not be combined.

Notably, the upstream change to `CFeeRate` has not been verified to exist in our repo.