### PR TITLE
Remove redundant explicitly defined copy constructors

### DIFF
--- a/src/amount.h
+++ b/src/amount.h
@@ -47,7 +47,6 @@ public:
     explicit CFeeRate(const CAmount& _nSatoshisPerK): nSatoshisPerK(_nSatoshisPerK) { }
     /** Constructor for a fee rate in satoshis per kB. The size in bytes must not exceed (2^63 - 1)*/
     CFeeRate(const CAmount& nFeePaid, size_t nBytes);
-    CFeeRate(const CFeeRate& other) { nSatoshisPerK = other.nSatoshisPerK; }
     /**
      * Return the fee in satoshis for the given size in bytes.
      */

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -47,11 +47,6 @@ CTxMemPoolEntry::CTxMemPoolEntry(const CTransactionRef& _tx, const CAmount& _nFe
     nSigOpCostWithAncestors = sigOpCost;
 }
 
-CTxMemPoolEntry::CTxMemPoolEntry(const CTxMemPoolEntry& other)
-{
-    *this = other;
-}
-
 double
 CTxMemPoolEntry::GetPriority(unsigned int currentHeight) const
 {

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -119,8 +119,6 @@ public:
                     int64_t _nTime, double _entryPriority, unsigned int _entryHeight,
                     CAmount _inChainInputValue, bool spendsCoinbase,
                     int64_t nSigOpsCost, LockPoints lp);
-    
-    CTxMemPoolEntry(const CTxMemPoolEntry& other);
 
     const CTransaction& GetTx() const { return *this->tx; }
     CTransactionRef GetSharedTx() const { return this->tx; }


### PR DESCRIPTION
Remove redundant explicitly defined copy ctors CFeeRate and CTxMemPoolEntry have explicitly defined copy ctors which has the same functionality as the implicit default copy ctors which would have been generated otherwise.

Besides being redundant, it violates the rule of three (see https://en.wikipedia.org/wiki/Rule_of_three_(C%2B%2B_programming). (Of course, the rule of three doesn't -really- cause a resource management issue here, but the reason for that is exactly that there is no need for an explicit copy ctor in the first place since no resourcesare being managed).

CFeeRate has an explicitly defined copy ctor which has the same functionality as the implicit default copy ctor which would have been generated otherwise.

Credit Doge Core devs [PR #2497](https://github.com/dogecoin/dogecoin/pull/2497/commits/6efc333ffe4744c325a3b595b26427f144b658c3)