### PR TITLE
Add fallthrough to solve compiler warning

### DIFF
--- a/src/hash.cpp
+++ b/src/hash.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2013-2016 The Bitcoin Core developers
+// Copyright (c) 2013-2023 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -49,8 +50,10 @@ unsigned int MurmurHash3(unsigned int nHashSeed, const std::vector<unsigned char
         switch (vDataToHash.size() & 3) {
         case 3:
             k1 ^= tail[2] << 16;
+            [[fallthrough]];
         case 2:
             k1 ^= tail[1] << 8;
+            [[fallthrough]];
         case 1:
             k1 ^= tail[0];
             k1 *= c1;


### PR DESCRIPTION
This fall through is intentional and should not be diagnosed by a compiler that warns on fallthrough.