### PR TITLE
Avoid strncpy for CMessageHeader::pchCommand

### DIFF
--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -1,7 +1,6 @@
-// Copyright (c) 2007-2010 Satoshi Nakamoto
-// Copyright (c) 2009-2015 The Bitcoin Core developers
-// Copyright (c) 2011-2017 The Litecoin Core developers
-// Copyright (c) 2013-2018 The Goldcoin Core developers
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2020 The Bitcoin Core developers
+// Copyright (c) 2013-2023 The Goldcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -90,8 +89,12 @@ CMessageHeader::CMessageHeader(const MessageStartChars& pchMessageStartIn)
 CMessageHeader::CMessageHeader(const MessageStartChars& pchMessageStartIn, const char* pszCommand, unsigned int nMessageSizeIn)
 {
     memcpy(pchMessageStart, pchMessageStartIn, MESSAGE_START_SIZE);
-    memset(pchCommand, 0, sizeof(pchCommand));
-    strncpy(pchCommand, pszCommand, COMMAND_SIZE);
+    // Copy pszCommand to pchCommand field with zero padding
+    bool in_padding = false;
+    for (size_t pos = 0; pos < COMMAND_SIZE; ++pos) {
+        pchCommand[pos] = in_padding ? 0 : pszCommand[pos];
+        in_padding = (pchCommand[pos] == 0);
+    }
     nMessageSize = nMessageSizeIn;
     memset(pchChecksum, 0, CHECKSUM_SIZE);
 }


### PR DESCRIPTION
The warning is spurious, as we exactly want the truncation behaviour here (no zero padding in pchCommand when the input has length exactly 12), but it seems hard to avoid.

The reason is that strncopy is designed to operate on C strings, and our target isn't exactly a C string.