### PR TITLE
Remove unused invalid function in Init.cpp

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1,7 +1,6 @@
-// Copyright (c) 2007-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2010 Satoshi Nakamoto
 // Copyright (c) 2009-2015 The Bitcoin Core developers
-// Copyright (c) 2011-2017 The Litecoin Core developers
-// Copyright (c) 2013-2018 The Goldcoin Core developers
+// Copyright (c) 2013-2023 The Goldcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -1055,9 +1054,6 @@ bool AppInitParameterInteraction()
 
     if (GetBoolArg("-peerbloomfilters", DEFAULT_PEERBLOOMFILTERS))
         nLocalServices = ServiceFlags(nLocalServices | NODE_BLOOM);
-
-    if (GetBoolArg("-rpcserialversion", DEFAULT_RPC_SERIALIZE_VERSION) < 0)
-        return InitError("rpcserialversion must be non-negative.");
 
     if (GetBoolArg("-rpcserialversion", DEFAULT_RPC_SERIALIZE_VERSION) > 0) //No segwit! (command itself is kept to keep compatibility)
         return InitError("unknown rpcserialversion requested.");


### PR DESCRIPTION
This fixes the bug addressed in issue #84

There are still several uses of the static const DEFAULT_RPC_SERIALIZE_VERSION sprinkled throughout the codebase. However, they are not impacting client function, and do not cause compile warnings. We can take additional steps to remove the remaining fragments as time permits.

This change has been tested and builds without the previous warning.