### PR TITLE
Confirm Fall Throughs to fix Warnings

### DIFF
--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2011-2016 The Bitcoin Core developers
+// Copyright (c) 2013-2023 The Goldcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -265,6 +266,7 @@ bool RPCConsole::RPCParseCommandLine(std::string &strResult, const std::string &
                 if (breakParsing)
                     break;
             }
+	    // Falls through
             case STATE_ARGUMENT: // In or after argument
             case STATE_EATING_SPACES_IN_ARG:
             case STATE_EATING_SPACES_IN_BRACKETS:

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -372,6 +372,7 @@ bool RPCConsole::RPCParseCommandLine(std::string &strResult, const std::string &
                 strResult = lastResult.get_str();
             else
                 strResult = lastResult.write(2);
+            // Falls through
         case STATE_ARGUMENT:
         case STATE_EATING_SPACES:
             return true;

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -463,7 +463,8 @@ static bool rest_getutxos(HTTPRequest* req, const std::string& strURIPart)
         std::vector<unsigned char> strRequestV = ParseHex(strRequestMutable);
         strRequestMutable.assign(strRequestV.begin(), strRequestV.end());
     }
-
+    // Falls through
+            
     case RF_BINARY: {
         try {
             //deserialize only if user sent a request

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -614,9 +614,12 @@ UniValue getblocktemplate(const JSONRPCRequest& request)
                 // Not exposed to GBT at all
                 break;
             case THRESHOLD_LOCKED_IN:
-                // Ensure bit is set in block version
+            {
+                // Ensure bit is set in block version, then fall through to get vbavailable set
                 pblock->nVersion |= VersionBitsMask(consensusParams, pos);
-                // FALL THROUGH to get vbavailable set...
+
+            {
+            // Falls through
             case THRESHOLD_STARTED:
             {
                 const struct BIP9DeploymentInfo& vbinfo = VersionBitsDeploymentInfo[pos];

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -617,8 +617,7 @@ UniValue getblocktemplate(const JSONRPCRequest& request)
             {
                 // Ensure bit is set in block version, then fall through to get vbavailable set
                 pblock->nVersion |= VersionBitsMask(consensusParams, pos);
-
-            {
+            }
             // Falls through
             case THRESHOLD_STARTED:
             {


### PR DESCRIPTION
This fixes the remaining compiler warnings on intentional Fall Throughs.