### PR TITLE
Critical v0.16.0 compatibility and stability fixes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,11 +1,11 @@
 dnl require autoconf 2.60 (AS_ECHO/AS_ECHO_N)
 AC_PREREQ([2.60])
 define(_CLIENT_VERSION_MAJOR, 0)
-define(_CLIENT_VERSION_MINOR, 15)
+define(_CLIENT_VERSION_MINOR, 16)
 define(_CLIENT_VERSION_REVISION, 0)
 define(_CLIENT_VERSION_BUILD, 0)
 define(_CLIENT_VERSION_IS_RELEASE, true)
-define(_COPYRIGHT_YEAR, 2023)
+define(_COPYRIGHT_YEAR, 2025)
 define(_COPYRIGHT_HOLDERS,[The %s developers])
 define(_COPYRIGHT_HOLDERS_SUBSTITUTION,[[Goldcoin Core]])
 AC_INIT([Goldcoin Core],[_CLIENT_VERSION_MAJOR._CLIENT_VERSION_MINOR._CLIENT_VERSION_REVISION],[https://github.com/goldcoin/goldcoin/issues],[goldcoin],[https://www.goldcoinproject.org])
@@ -55,7 +55,7 @@ case $host in
   ;;
 esac
 dnl Require C++11 compiler (no GNU extensions)
-AX_CXX_COMPILE_STDCXX([11], [noext], [mandatory], [nodefault])
+AX_CXX_COMPILE_STDCXX([14], [noext], [mandatory], [nodefault])
 dnl Check if -latomic is required for <std::atomic>
 CHECK_ATOMIC
 

--- a/src/bench/bench.h
+++ b/src/bench/bench.h
@@ -7,6 +7,7 @@
 
 #include <map>
 #include <string>
+#include <limits> // For std::numeric_limits (required for GCC 13+)
 
 #include <boost/function.hpp>
 #include <boost/preprocessor/cat.hpp>

--- a/src/clientversion.h
+++ b/src/clientversion.h
@@ -15,8 +15,8 @@
 
 //! These need to be macros, as clientversion.cpp's and bitcoin*-res.rc's voodoo requires it
 #define CLIENT_VERSION_MAJOR 0
-#define CLIENT_VERSION_MINOR 14
-#define CLIENT_VERSION_REVISION 9
+#define CLIENT_VERSION_MINOR 16
+#define CLIENT_VERSION_REVISION 0
 #define CLIENT_VERSION_BUILD 0
 
 //! Set to true for release, false for prerelease or test build
@@ -26,7 +26,7 @@
  * Copyright year (2009-this)
  * Todo: update this when changing our copyright comments in the source
  */
-#define COPYRIGHT_YEAR 2023
+#define COPYRIGHT_YEAR 2025
 
 #endif //HAVE_CONFIG_H
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1620,7 +1620,11 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
         while (!fHaveGenesis) {
             condvar_GenesisWait.wait(lock);
         }
-        uiInterface.NotifyBlockTip.disconnect(BlockNotifyGenesisWait);
+        // Boost 1.83+ compatibility: disconnect_all_slots() is safer than
+        // trying to disconnect a specific function pointer
+        // TODO: Better solution would be to track the connection with
+        // boost::signals2::scoped_connection at connection time
+        uiInterface.NotifyBlockTip.disconnect_all_slots();
     }
 
     // ********************************************************* Step 11: start node

--- a/src/qt/paymentserver.cpp
+++ b/src/qt/paymentserver.cpp
@@ -554,7 +554,8 @@ bool PaymentServer::processPaymentRequest(const PaymentRequestPlus& request, Sen
     QList<std::pair<CScript, CAmount> > sendingTos = request.getPayTo();
     QStringList addresses;
 
-    Q_FOREACH(const PAIRTYPE(CScript, CAmount)& sendingTo, sendingTos) {
+    // Qt 5.15+ compatibility: Replace Q_FOREACH with range-based for
+    for (const auto& sendingTo : sendingTos) {
         // Extract and check destination addresses
         CTxDestination dest;
         if (ExtractDestination(sendingTo.first, dest)) {

--- a/src/qt/test/paymentservertests.cpp
+++ b/src/qt/test/paymentservertests.cpp
@@ -196,7 +196,8 @@ void PaymentServerTests::paymentServerTests()
     QVERIFY(r.paymentRequest.IsInitialized());
     // Extract address and amount from the request
     QList<std::pair<CScript, CAmount> > sendingTos = r.paymentRequest.getPayTo();
-    Q_FOREACH (const PAIRTYPE(CScript, CAmount)& sendingTo, sendingTos) {
+    // Qt 5.15+ compatibility: Replace Q_FOREACH with range-based for
+    for (const auto& sendingTo : sendingTos) {
         CTxDestination dest;
         if (ExtractDestination(sendingTo.first, dest))
             QCOMPARE(PaymentServer::verifyAmount(sendingTo.second), false);

--- a/src/qt/transactiondesc.cpp
+++ b/src/qt/transactiondesc.cpp
@@ -245,14 +245,16 @@ QString TransactionDesc::toHTML(CWallet *wallet, CWalletTx &wtx, TransactionReco
     strHTML += "<b>" + tr("Output index") + ":</b> " + QString::number(rec->getOutputIndex()) + "<br>";
 
     // Message from normal bitcoin:URI (bitcoin:123...?message=example)
-    Q_FOREACH (const PAIRTYPE(std::string, std::string)& r, wtx.vOrderForm)
+    // Qt 5.15+ compatibility: Replace Q_FOREACH with range-based for
+    for (const auto& r : wtx.vOrderForm)
         if (r.first == "Message")
             strHTML += "<br><b>" + tr("Message") + ":</b><br>" + GUIUtil::HtmlEscape(r.second, true) + "<br>";
 
     //
     // PaymentRequest info:
     //
-    Q_FOREACH (const PAIRTYPE(std::string, std::string)& r, wtx.vOrderForm)
+    // Qt 5.15+ compatibility: Replace Q_FOREACH with range-based for
+    for (const auto& r : wtx.vOrderForm)
     {
         if (r.first == "PaymentRequest")
         {

--- a/src/test/cuckoocache_tests.cpp
+++ b/src/test/cuckoocache_tests.cpp
@@ -6,6 +6,7 @@
 #include "test/test_bitcoin.h"
 #include "random.h"
 #include <thread>
+#include <deque> // For std::deque (required for GCC 13+)
 #include <boost/thread.hpp>
 
 


### PR DESCRIPTION
- Fix Boost 1.83+ signals2 compatibility (prevents segfaults)
- Add missing C++ headers for GCC 13+ (limits, deque)
- Replace deprecated Q_FOREACH with range-based for loops
- Upgrade to C++14 standard for modern compiler support
- Update copyright year to 2025
- Fix version to 0.16.0 (was incorrectly 0.14.9)

These fixes address build failures and potential runtime segfaults when building with modern toolchains (Boost 1.83+, GCC 13+, Qt 5.15+).

Block explorer administrators reported segfaults with early v0.16.0 builds - these patches resolve those issues.